### PR TITLE
RDKEMW-4353:Implement logs to remain

### DIFF
--- a/src/NativeJSRenderer.cpp
+++ b/src/NativeJSRenderer.cpp
@@ -365,7 +365,7 @@ void NativeJSRenderer::runJavaScriptInternal(ApplicationRequest& appRequest)
 	if(!code.empty())
 	{
 		NativeJSLogger::log(INFO, "Running the JavaScript code\n");
-		IJavaScriptContext* context = mContextMap[id].context;
+		JavaScriptContext* context = (JavaScriptContext*)mContextMap[id].context;
 		std::string rawcode = code ;
 		bool ret = context-> runScript(rawcode.c_str(),true,"JavaScriptCode",nullptr,true);
 		double duration = context->getExecutionDuration();


### PR DESCRIPTION
Reason for change: Fixing build errors in NativeJSRenderer.cpp Test Procedure:Build should complete without error. Risks: low
Priority: P2